### PR TITLE
support variable bytes per poll

### DIFF
--- a/src/chaff.rs
+++ b/src/chaff.rs
@@ -34,12 +34,12 @@ impl std::fmt::Display for ChunkSizeTooSmallError {
 impl std::error::Error for ChunkSizeTooSmallError {}
 
 #[derive(Debug, Clone, Copy)]
-pub struct ChaffArgs {
+pub struct ChaffStreamArgs {
 	output_length: usize,
 	chunk_size: usize
 }
 
-impl ChaffArgs {
+impl ChaffStreamArgs {
 	/// The `output_length` parameter controls the size of the hypothetical chaff input file.
 	/// In other words, the length of the stream is the length of the headers plus `output_length`.
 	pub fn with_length(output_length: usize) -> Self {
@@ -60,7 +60,7 @@ impl ChaffArgs {
 }
 
 impl<RNG:TryRng> ChaffStream<RNG> {
-	pub fn new(args: ChaffArgs, rng: RNG) -> Self {
+	pub fn new(args: ChaffStreamArgs, rng: RNG) -> Self {
 		debug_assert!(args.chunk_size >= MIN_CHUNK_SIZE);
 
 		Self {

--- a/src/chaff.rs
+++ b/src/chaff.rs
@@ -23,34 +23,52 @@ pin_project_lite::pin_project! {
 const MIN_CHUNK_SIZE: usize = HEADER_LENGTH;
 
 #[derive(Debug)]
-pub enum NewChaffStreamError {
-	ChunkSizeTooSmall
-}
+pub struct ChunkSizeTooSmallError;
 
-impl std::fmt::Display for NewChaffStreamError {
+impl std::fmt::Display for ChunkSizeTooSmallError {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-		match self {
-			Self::ChunkSizeTooSmall => write!(f, "chunk size too small, must be at least {MIN_CHUNK_SIZE} bytes")
-		}
+		write!(f, "chunk size too small, must be at least {MIN_CHUNK_SIZE} bytes")
 	}
 }
 
-impl std::error::Error for NewChaffStreamError {}
+impl std::error::Error for ChunkSizeTooSmallError {}
 
-impl<RNG:TryRng> ChaffStream<RNG> {
+#[derive(Debug, Clone, Copy)]
+pub struct ChaffArgs {
+	output_length: usize,
+	chunk_size: usize
+}
+
+impl ChaffArgs {
 	/// The `output_length` parameter controls the size of the hypothetical chaff input file.
 	/// In other words, the length of the stream is the length of the headers plus `output_length`.
-	pub fn new(rng: RNG, output_length: usize, chunk_size: usize) -> Result<Self, NewChaffStreamError> {
+	pub fn with_length(output_length: usize) -> Self {
+		Self {
+			output_length,
+			chunk_size: 2048
+		}
+	}
+
+	pub fn set_chunk_size(&mut self, chunk_size: usize) -> Result<(), ChunkSizeTooSmallError> {
 		if chunk_size < MIN_CHUNK_SIZE {
-			return Err(NewChaffStreamError::ChunkSizeTooSmall);
+			return Err(ChunkSizeTooSmallError);
 		}
 
-		Ok(Self {
+		self.chunk_size = chunk_size;
+		Ok(())
+	}
+}
+
+impl<RNG:TryRng> ChaffStream<RNG> {
+	pub fn new(args: ChaffArgs, rng: RNG) -> Self {
+		debug_assert!(args.chunk_size >= MIN_CHUNK_SIZE);
+
+		Self {
 			rng,
 			state: ChaffState::PreHeader,
-			remaining_bytes: output_length,
-			chunk_size
-		})
+			remaining_bytes: args.output_length,
+			chunk_size: args.chunk_size
+		}
 	}
 }
 
@@ -66,7 +84,7 @@ impl<RNG: TryRng> Stream for ChaffStream<RNG> {
 		match this.state {
 			ChaffState::PreHeader => {
 				let output_len: usize = (HEADER_LENGTH + *this.remaining_bytes).min(*this.chunk_size);
-				assert!(output_len >= HEADER_LENGTH);
+				debug_assert!(output_len >= HEADER_LENGTH);
 
 				let mut output = Vec::with_capacity(output_len);
 

--- a/src/decrypt.rs
+++ b/src/decrypt.rs
@@ -7,22 +7,47 @@ use core::pin::Pin;
 use core::fmt::Display;
 use core::error::Error;
 use core::task::{Context, Poll, ready};
+use core::num::NonZeroUsize;
 use crate::util::{HmacSha3_256, kdf, compute_verification_hash};
-use crate::{BYTES_PER_POLL, Aes256Ctr};
+use crate::{DEFAULT_BYTES_PER_POLL, Aes256Ctr};
+
+/// builder for arguments to [Decrypt::new] with default values, can be constructed with [DecryptArgs::default]
+#[derive(Debug, Clone, Copy)]
+pub struct DecryptArgs {
+	bytes_per_poll: NonZeroUsize
+}
+
+impl Default for DecryptArgs {
+	/// default settings are not part of semver contract
+	fn default() -> Self {
+		Self {
+			bytes_per_poll: DEFAULT_BYTES_PER_POLL
+		}
+	}
+}
+
+impl DecryptArgs {
+	/// sets the maximum number of bytes to decrypt before yielding to the executor
+	pub fn set_bytes_per_poll(&mut self, bytes_per_poll: NonZeroUsize) {
+		self.bytes_per_poll = bytes_per_poll;
+	}
+}
 
 pin_project_lite::pin_project! {
 	pub struct Decrypt<R> {
 		#[pin]
 		read: Option<R>,
-		buffer: Option<BytesMut>
+		buffer: Option<BytesMut>,
+		bytes_per_poll: NonZeroUsize
 	}
 }
 
 impl<R> Decrypt<R> {
-	pub fn new(read: R) -> Self {
+	pub fn new(additional_args: DecryptArgs, read: R) -> Self {
 		Self {
 			read: Some(read),
-			buffer: Some(BytesMut::new())
+			buffer: Some(BytesMut::new()),
+			bytes_per_poll: additional_args.bytes_per_poll
 		}
 	}
 }
@@ -105,7 +130,8 @@ impl<E, R: Stream<Item = Result<Bytes, E>> + Unpin> Future for Decrypt<R> {
 				verification_hash,
 				iv,
 				version_byte: header[4],
-				compression_algo: header[5]
+				compression_algo: header[5],
+				bytes_per_poll: *this.bytes_per_poll
 			})))
 		} else {
 			let read = this.read.as_pin_mut().unwrap();
@@ -131,7 +157,8 @@ pub struct DecryptAwaitingPassword<R> {
 	verification_hash: [u8; 64],
 	iv: [u8; 16],
 	version_byte: u8,
-	compression_algo: u8
+	compression_algo: u8,
+	bytes_per_poll: NonZeroUsize
 }
 
 const HMAC_LEN: usize = 32;
@@ -169,7 +196,8 @@ impl<R> DecryptAwaitingPassword<R> {
 			Ok(DecryptStream {
 				read: self.read,
 				state,
-				buffer: self.buffer
+				buffer: self.buffer,
+				bytes_per_poll: self.bytes_per_poll
 			})
 		} else {
 			Err(self)
@@ -195,6 +223,7 @@ pin_project_lite::pin_project! {
 		read: R,
 		state: DecryptState,
 		buffer: BytesMut,
+		bytes_per_poll: NonZeroUsize
 	}
 }
 
@@ -244,7 +273,7 @@ where
 
 		match this.state {
 			DecryptState::PostHeader(state) => {
-				if state.eof && this.buffer.len() <= BYTES_PER_POLL {
+				if state.eof && this.buffer.len() <= this.bytes_per_poll.get() {
 					if state.eof_buf.len() < HMAC_LEN {
 						*this.state = DecryptState::Done;
 						return Poll::Ready(Some(Err(DecryptStreamError::TooShort)));
@@ -266,8 +295,8 @@ where
 					*this.state = DecryptState::Done;
 
 					Poll::Ready(Some(Ok(data.freeze())))
-				} else if this.buffer.len() >= BYTES_PER_POLL {
-					let mut data = this.buffer.split_to(BYTES_PER_POLL);
+				} else if this.buffer.len() >= this.bytes_per_poll.get() {
+					let mut data = this.buffer.split_to(this.bytes_per_poll.get());
 
 					state.integrity_code.as_mut().unwrap().update(&data);
 					state.aes.apply_keystream(&mut data);

--- a/src/encrypt.rs
+++ b/src/encrypt.rs
@@ -5,8 +5,31 @@ use ctr::cipher::{KeyIvInit, StreamCipher};
 use hmac::{Mac, KeyInit};
 use core::pin::Pin;
 use core::task::{Context, Poll, ready};
+use core::num::NonZeroUsize;
 use crate::util::{HmacSha3_256, new_arr, kdf, compute_verification_hash};
-use crate::{BYTES_PER_POLL, Aes256Ctr};
+use crate::{DEFAULT_BYTES_PER_POLL, Aes256Ctr};
+
+/// builder for arguments to [Encrypt::new] with default values, can be constructed with [EncryptArgs::default]
+#[derive(Debug, Clone, Copy)]
+pub struct EncryptArgs {
+	bytes_per_poll: NonZeroUsize
+}
+
+impl Default for EncryptArgs {
+	/// default settings are not part of semver contract
+	fn default() -> Self {
+		Self {
+			bytes_per_poll: DEFAULT_BYTES_PER_POLL
+		}
+	}
+}
+
+impl EncryptArgs {
+	/// sets the maximum number of bytes to encrypt before yielding to the executor
+	pub fn set_bytes_per_poll(&mut self, bytes_per_poll: NonZeroUsize) {
+		self.bytes_per_poll = bytes_per_poll;
+	}
+}
 
 enum EncryptState {
 	PreHeader,
@@ -25,7 +48,8 @@ pin_project_lite::pin_project! {
 		integrity_code: Option<HmacSha3_256>,
 		state: EncryptState,
 		block_buffer: BytesMut,
-		iv: [u8; 16]
+		iv: [u8; 16],
+		bytes_per_poll: NonZeroUsize
 	}
 }
 
@@ -34,7 +58,12 @@ impl<R> Encrypt<R> {
 	/// If you're using Tokio I advise that you wrap this call in a `spawn_blocking`.
 	///
 	/// SECURITY: It is advisable to zero out the memory containing the password after this method returns.
-	pub fn new_uncompressed<RNG: TryCryptoRng>(read: R, password: &[u8], rng: &mut RNG) -> Result<Self, RNG::Error> {
+	pub fn new<RNG: TryCryptoRng>(
+		additional_args: EncryptArgs,
+		rng: &mut RNG,
+		password: &[u8],
+		read: R
+	) -> Result<Self, RNG::Error> {
 		let mut password_salt = new_arr::<32>();
 		rng.try_fill_bytes(password_salt.as_mut())?;
 
@@ -54,7 +83,8 @@ impl<R> Encrypt<R> {
 			integrity_code: Some(HmacSha3_256::new_from_slice(aes_key.as_ref().get_ref()).unwrap()),
 			state: EncryptState::PreHeader,
 			block_buffer: BytesMut::new(),
-			iv
+			iv,
+			bytes_per_poll: additional_args.bytes_per_poll
 		})
 	}
 }
@@ -108,8 +138,8 @@ impl<E, R: Stream<Item = Result<Bytes, E>>> Stream for Encrypt<R> {
 					return Poll::Ready(Some(Ok(Bytes::from_owner(buf))));
 				},
 				EncryptState::PostHeader => {
-					if this.block_buffer.len() >= BYTES_PER_POLL {
-						let mut data = this.block_buffer.split_to(BYTES_PER_POLL);
+					if this.block_buffer.len() >= this.bytes_per_poll.get() {
+						let mut data = this.block_buffer.split_to(this.bytes_per_poll.get());
 						this.aes.apply_keystream(&mut data);
 						this.integrity_code.as_mut().unwrap().update(&data);
 
@@ -132,7 +162,7 @@ impl<E, R: Stream<Item = Result<Bytes, E>>> Stream for Encrypt<R> {
 					}
 				},
 				EncryptState::Finalizing => {
-					debug_assert!(this.block_buffer.len() < BYTES_PER_POLL);
+					debug_assert!(this.block_buffer.len() < this.bytes_per_poll.get());
 
 					let mut final_data = this.block_buffer.split();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@ pub mod decrypt;
 pub use decrypt::{Decrypt, DecryptArgs};
 
 pub mod chaff;
-pub use chaff::ChaffStream;
+pub use chaff::{ChaffStream, ChaffArgs};
 
 #[cfg(test)]
 mod tests;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@ pub mod decrypt;
 pub use decrypt::{Decrypt, DecryptArgs};
 
 pub mod chaff;
-pub use chaff::{ChaffStream, ChaffArgs};
+pub use chaff::{ChaffStream, ChaffStreamArgs};
 
 #[cfg(test)]
 mod tests;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,15 +1,16 @@
 mod util;
 
+const DEFAULT_BYTES_PER_POLL: core::num::NonZeroUsize = core::num::NonZeroUsize::new(128).unwrap();
+
 const HEADER_LENGTH: usize = 150;
-const BYTES_PER_POLL: usize = 128;
 
 type Aes256Ctr = ctr::Ctr64LE<aes::Aes256>;
 
 pub mod encrypt;
-pub use encrypt::Encrypt;
+pub use encrypt::{Encrypt, EncryptArgs};
 
 pub mod decrypt;
-pub use decrypt::Decrypt;
+pub use decrypt::{Decrypt, DecryptArgs};
 
 pub mod chaff;
 pub use chaff::ChaffStream;

--- a/src/qc_tests.rs
+++ b/src/qc_tests.rs
@@ -2,9 +2,10 @@ use futures_util::StreamExt;
 use bytes::{Bytes, BytesMut};
 use rand_core::{Rng, SeedableRng};
 use quickcheck::TestResult;
+use core::num::NonZeroUsize;
 use std::sync::Arc;
-use crate::encrypt::Encrypt;
-use crate::decrypt::Decrypt;
+use crate::encrypt::{Encrypt, EncryptArgs};
+use crate::decrypt::{Decrypt, DecryptArgs};
 
 struct OwnedRandomChunksIter<const S: usize, V, R> {
 	vec: Arc<V>,
@@ -55,9 +56,16 @@ fn init_buffer<R: Rng>(mut rng: R, length: usize) -> Vec<u8> {
 	b
 }
 
+// TODO: fix double test, both these attribute macros add their own `#[test]`
 #[tokio::test]
 #[quickcheck_macros::quickcheck]
-async fn end_to_end(rng_seed: u64, input_length: usize, password: Vec<u8>) -> TestResult {
+async fn end_to_end(
+	rng_seed: u64,
+	input_length: usize,
+	password: Vec<u8>,
+	bytes_per_poll_enc: NonZeroUsize,
+	bytes_per_poll_dec: NonZeroUsize
+) -> TestResult {
 	if input_length > MAX_SIZE {
 		return TestResult::discard();
 	}
@@ -72,7 +80,9 @@ async fn end_to_end(rng_seed: u64, input_length: usize, password: Vec<u8>) -> Te
 			.map(Result::<Bytes, std::io::Error>::Ok);
 
 		let mut password_rng = rand::rngs::StdRng::seed_from_u64(rng_seed);
-		Encrypt::new_uncompressed(s, &password_enc, &mut password_rng).unwrap()
+		let mut args = EncryptArgs::default();
+		args.set_bytes_per_poll(bytes_per_poll_enc);
+		Encrypt::new(args, &mut password_rng, &password_enc, s).unwrap()
 	}).await.unwrap();
 
 	let encrypted: Bytes = encryptor.map(|c| c.unwrap())
@@ -82,7 +92,9 @@ async fn end_to_end(rng_seed: u64, input_length: usize, password: Vec<u8>) -> Te
 	let s = futures_util::stream::iter(OwnedRandomChunksIter::<99999, _, _>::new(Arc::new(encrypted), dec_chunk_rng))
 		.map(Result::<Bytes, std::io::Error>::Ok);
 
-	let decryptor = Decrypt::new(s).await.unwrap();
+	let mut args = DecryptArgs::default();
+	args.set_bytes_per_poll(bytes_per_poll_dec);
+	let decryptor = Decrypt::new(args, s).await.unwrap();
 	let decryptor = tokio::task::spawn_blocking(move || {
 		let Ok(stream) = decryptor.try_password(&password) else { panic!("password should be correct") };
 		stream

--- a/src/qc_tests.rs
+++ b/src/qc_tests.rs
@@ -6,6 +6,7 @@ use core::num::NonZeroUsize;
 use std::sync::Arc;
 use crate::encrypt::{Encrypt, EncryptArgs};
 use crate::decrypt::{Decrypt, DecryptArgs};
+use crate::chaff::{ChaffStream, ChaffArgs};
 
 struct OwnedRandomChunksIter<const S: usize, V, R> {
 	vec: Arc<V>,
@@ -102,4 +103,48 @@ async fn end_to_end(
 	let decrypted = decryptor.map(|c| c.unwrap()).collect::<BytesMut>().await.freeze();
 
 	TestResult::from_bool(input.as_ref().eq(&decrypted))
+}
+
+// TODO: fix double test, both these attribute macros add their own `#[test]`
+#[tokio::test]
+#[quickcheck_macros::quickcheck]
+async fn chaff(
+	rng_seed: u64,
+	input_length: usize,
+	chunk_size: usize,
+	password: Vec<u8>,
+	bytes_per_poll_dec: NonZeroUsize
+) -> TestResult {
+	if input_length > MAX_SIZE {
+		return TestResult::discard();
+	}
+
+	let mut args = ChaffArgs::with_length(input_length);
+	let chunk_res = args.set_chunk_size(chunk_size);
+	if chunk_res.is_err() {
+		return TestResult::discard();
+	}
+
+	let rng = rand::rngs::StdRng::seed_from_u64(rng_seed);
+
+	let chaff = ChaffStream::new(args, rng);
+	let chaff_output: Bytes = chaff.map(|c| {
+		let chunk = c.unwrap();
+		assert!(chunk.len() <= chunk_size);
+		chunk
+	}).collect::<BytesMut>().await.freeze();
+
+	let dec_chunk_rng = rand::rngs::StdRng::seed_from_u64(rng_seed);
+	let s = futures_util::stream::iter(OwnedRandomChunksIter::<99999, _, _>::new(Arc::new(chaff_output), dec_chunk_rng))
+		.map(Result::<Bytes, std::io::Error>::Ok);
+
+	let mut args = DecryptArgs::default();
+	args.set_bytes_per_poll(bytes_per_poll_dec);
+	let decryptor = Decrypt::new(args, s).await.unwrap();
+	let decryptor = tokio::task::spawn_blocking(move || {
+		decryptor.try_password(&password)
+	}).await.unwrap();
+
+	// decryption should always fail, obviously
+	TestResult::from_bool(decryptor.is_err())
 }

--- a/src/qc_tests.rs
+++ b/src/qc_tests.rs
@@ -6,7 +6,7 @@ use core::num::NonZeroUsize;
 use std::sync::Arc;
 use crate::encrypt::{Encrypt, EncryptArgs};
 use crate::decrypt::{Decrypt, DecryptArgs};
-use crate::chaff::{ChaffStream, ChaffArgs};
+use crate::chaff::{ChaffStream, ChaffStreamArgs};
 
 struct OwnedRandomChunksIter<const S: usize, V, R> {
 	vec: Arc<V>,
@@ -119,7 +119,7 @@ async fn chaff(
 		return TestResult::discard();
 	}
 
-	let mut args = ChaffArgs::with_length(input_length);
+	let mut args = ChaffStreamArgs::with_length(input_length);
 	let chunk_res = args.set_chunk_size(chunk_size);
 	if chunk_res.is_err() {
 		return TestResult::discard();

--- a/src/qc_tests.rs
+++ b/src/qc_tests.rs
@@ -29,7 +29,6 @@ impl<const S: usize, V: AsRef<[u8]>, R: Rng> OwnedRandomChunksIter<S, V, R> {
 }
 
 impl<const S: usize, V: AsRef<[u8]>, R: Rng> std::iter::Iterator for OwnedRandomChunksIter<S, V, R> {
-	// returning a slice here would require `Item` to have a generic lifetime
 	type Item = Bytes;
 
 	fn next(&mut self) -> Option<Self::Item> {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -3,7 +3,7 @@ use bytes::{Bytes, BytesMut};
 use rand_core::SeedableRng;
 use crate::encrypt::{Encrypt, EncryptArgs};
 use crate::decrypt::{Decrypt, DecryptArgs, DecryptStreamError};
-use crate::chaff::ChaffStream;
+use crate::chaff::{ChaffStream, ChaffArgs};
 use crate::HEADER_LENGTH;
 
 const RNG_SEED: u64 = 12345678;
@@ -204,8 +204,15 @@ macro_rules! test_chaff {
 		async fn $n() {
 			let rng = rand::rngs::StdRng::seed_from_u64(RNG_SEED);
 
-			let chaff_stream = ChaffStream::new(rng, $l, 1000).unwrap();
-			let chaff_data = chaff_stream.map(|c| c.unwrap()).collect::<BytesMut>().await.freeze();
+			let mut args = ChaffArgs::with_length($l);
+			let chunk_size = 1000;
+			args.set_chunk_size(chunk_size).unwrap();
+			let chaff_stream = ChaffStream::new(args, rng);
+			let chaff_data = chaff_stream.map(|c| {
+				let chunk = c.unwrap();
+				assert!(chunk.len() <= chunk_size);
+				chunk
+			}).collect::<BytesMut>().await.freeze();
 			assert_eq!(chaff_data.len(), $l + HEADER_LENGTH);
 
 			let enc_chunks = chaff_data.chunks(1024)

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -3,7 +3,7 @@ use bytes::{Bytes, BytesMut};
 use rand_core::SeedableRng;
 use crate::encrypt::{Encrypt, EncryptArgs};
 use crate::decrypt::{Decrypt, DecryptArgs, DecryptStreamError};
-use crate::chaff::{ChaffStream, ChaffArgs};
+use crate::chaff::{ChaffStream, ChaffStreamArgs};
 use crate::HEADER_LENGTH;
 
 const RNG_SEED: u64 = 12345678;
@@ -204,7 +204,7 @@ macro_rules! test_chaff {
 		async fn $n() {
 			let rng = rand::rngs::StdRng::seed_from_u64(RNG_SEED);
 
-			let mut args = ChaffArgs::with_length($l);
+			let mut args = ChaffStreamArgs::with_length($l);
 			let chunk_size = 1000;
 			args.set_chunk_size(chunk_size).unwrap();
 			let chaff_stream = ChaffStream::new(args, rng);

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,8 +1,8 @@
 use futures_util::StreamExt;
 use bytes::{Bytes, BytesMut};
 use rand_core::SeedableRng;
-use crate::encrypt::Encrypt;
-use crate::decrypt::{Decrypt, DecryptStreamError};
+use crate::encrypt::{Encrypt, EncryptArgs};
+use crate::decrypt::{Decrypt, DecryptArgs, DecryptStreamError};
 use crate::chaff::ChaffStream;
 use crate::HEADER_LENGTH;
 
@@ -37,7 +37,7 @@ macro_rules! test_encrypt {
 			);
 
 			let mut encryptor = tokio::task::spawn_blocking(move || {
-				Encrypt::new_uncompressed(s, PASSWORD, &mut rng).unwrap()
+				Encrypt::new(EncryptArgs::default(), &mut rng, PASSWORD, s).unwrap()
 			}).await.unwrap();
 
 			while let Some(chunk) = encryptor.next().await {
@@ -65,7 +65,7 @@ macro_rules! test_end_to_end {
 				.map(Result::<Bytes, std::io::Error>::Ok);
 
 			let encryptor = tokio::task::spawn_blocking(move || {
-				Encrypt::new_uncompressed(s, PASSWORD, &mut rng).unwrap()
+				Encrypt::new(EncryptArgs::default(), &mut rng, PASSWORD, s).unwrap()
 			}).await.unwrap();
 
 			let encrypted: Bytes = encryptor.map(|c| c.unwrap())
@@ -76,7 +76,7 @@ macro_rules! test_end_to_end {
 			let s = futures_util::stream::iter(enc_chunks)
 				.map(Result::<Bytes, std::io::Error>::Ok);
 
-			let decryptor = Decrypt::new(s).await.unwrap();
+			let decryptor = Decrypt::new(DecryptArgs::default(), s).await.unwrap();
 			let decryptor = tokio::task::spawn_blocking(move || {
 				let Ok(stream) = decryptor.try_password(PASSWORD) else { panic!("password should be correct") };
 				stream
@@ -109,7 +109,7 @@ macro_rules! test_tamper_detection {
 			);
 
 			let encryptor = tokio::task::spawn_blocking(move || {
-				Encrypt::new_uncompressed(s, PASSWORD, &mut rng).unwrap()
+				Encrypt::new(EncryptArgs::default(), &mut rng, PASSWORD, s).unwrap()
 			}).await.unwrap();
 
 			let mut encrypted: BytesMut = encryptor.map(|c| c.unwrap()).collect().await;
@@ -118,7 +118,7 @@ macro_rules! test_tamper_detection {
 				std::future::ready(Result::<Bytes, std::io::Error>::Ok(encrypted.freeze()))
 			);
 
-			let decryptor = Decrypt::new(s).await.unwrap();
+			let decryptor = Decrypt::new(DecryptArgs::default(), s).await.unwrap();
 			let mut decryptor = tokio::task::spawn_blocking(move || {
 				let Ok(stream) = decryptor.try_password(PASSWORD) else { panic!("password should be correct") };
 				stream
@@ -161,7 +161,7 @@ macro_rules! test_password {
 			);
 
 			let encryptor = tokio::task::spawn_blocking(move || {
-				Encrypt::new_uncompressed(s, PASSWORD, &mut rng).unwrap()
+				Encrypt::new(EncryptArgs::default(), &mut rng, PASSWORD, s).unwrap()
 			}).await.unwrap();
 
 			let encrypted = encryptor.map(|c| c.unwrap()).collect::<BytesMut>().await.freeze();
@@ -169,7 +169,7 @@ macro_rules! test_password {
 				std::future::ready(Result::<Bytes, std::io::Error>::Ok(encrypted))
 			);
 
-			let decryptor = Decrypt::new(s).await.unwrap();
+			let decryptor = Decrypt::new(DecryptArgs::default(), s).await.unwrap();
 			let decryptor = tokio::task::spawn_blocking(move || {
 				decryptor.try_password(WRONG_PASSWORD)
 			}).await.unwrap();
@@ -213,7 +213,7 @@ macro_rules! test_chaff {
 			let s = futures_util::stream::iter(enc_chunks)
 				.map(Result::<Bytes, std::io::Error>::Ok);
 
-			let decryptor = Decrypt::new(s).await.unwrap();
+			let decryptor = Decrypt::new(DecryptArgs::default(), s).await.unwrap();
 			let decryptor = tokio::task::spawn_blocking(move || {
 				decryptor.try_password(WRONG_PASSWORD)
 			}).await.unwrap();


### PR DESCRIPTION
- support variable bytes per poll via new `EncryptArgs` and `DecryptArgs` types
- new `ChaffArgs` type (no change in functionality)